### PR TITLE
Setup android manifest for VR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,36 @@ ndk-glue = "0.2.1"
 [package.metadata.android]
 apk_label = "Bevy OpenXR wgpu"
 build_targets = ["aarch64-linux-android"]
-min_sdk_version = 16
-target_sdk_version = 29
 assets = "assets"
 libs = "libs"
+
+[package.metadata.android.sdk]
+min_sdk_version = 16
+target_sdk_version = 29
+
+[[package.metadata.android.application.meta_data]]
+name = "com.samsung.android.vr.application.mode"
+value = "vr_only"
+
+[[package.metadata.android.application.meta_data]]
+name = "com.oculus.supportedDevices"
+value = "quest|quest2"
+
+[package.metadata.android.application.activity]
+theme = "@android:style/Theme.Black.NoTitleBar.Fullscreen"
+config_changes = "density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|uiMode"
+launch_mode = "singleTask"
+orientation = "landscape"
+resizeable_activity = "false"
+
+[[package.metadata.android.application.activity.meta_data]]
+name = "com.oculus.vr.focusaware"
+value = "true"
+
+[[package.metadata.android.intent_filter]]
+actions = ["android.intent.action.MAIN"]
+categories = ["com.oculus.intent.category.VR", "android.intent.category.LAUNCHER"]
+data = []
 
 [[package.metadata.android.permission]]
 name = "com.oculus.permission.HAND_TRACKING"


### PR DESCRIPTION
As documented here:
https://developer.oculus.com/documentation/native/android/mobile-native-manifest/

Using the syntax of cargo-apk 0.7
https://crates.io/crates/cargo-apk

This fixes a few lifecyle issues. In particular, the app can be launched again through the oculus menu.